### PR TITLE
Fix TextBoxWidget cursor drifting left when deleting overflowed single-line text

### DIFF
--- a/src/Spectre.Tui.Tests/Widgets/TextBoxWidgetTests.cs
+++ b/src/Spectre.Tui.Tests/Widgets/TextBoxWidgetTests.cs
@@ -430,6 +430,23 @@ public sealed class TextBoxWidgetTests
         }
 
         [Fact]
+        public void Should_Keep_Cursor_Pinned_At_Right_Edge_When_Deleting_From_Overflowed_Text()
+        {
+            // Given
+            var box = new TextBoxWidget().Text("HelloWorldXYZ");
+            box.MoveToEnd();
+            var fixture = new TuiFixture(new Size(10, 1));
+            fixture.Render(box); // Establishes _horizontalOffset = 4, shows "oWorldXYZ•"
+
+            // When
+            box.DeleteBackward();
+            var result = fixture.Render(box);
+
+            // Then
+            result.ShouldBe("loWorldXY•");
+        }
+
+        [Fact]
         public void Should_Scroll_Vertically_To_Keep_Cursor_Visible_When_MultiLine()
         {
             // Given

--- a/src/Spectre.Tui/Widgets/TextBox/TextBoxWidget.cs
+++ b/src/Spectre.Tui/Widgets/TextBox/TextBoxWidget.cs
@@ -377,6 +377,14 @@ public sealed class TextBoxWidget : IWidget
             _horizontalOffset = cursorCellPos - width + 1;
         }
 
+        // When the cursor is at the end of the text and content is still scrolled off to the
+        // left, keep the cursor pinned to the right edge rather than letting it drift left as
+        // characters are deleted.
+        if (_cursorColumn == line.Count && _horizontalOffset > cursorCellPos - width + 1)
+        {
+            _horizontalOffset = Math.Max(0, cursorCellPos - width + 1);
+        }
+
         if (_horizontalOffset < 0)
         {
             _horizontalOffset = 0;


### PR DESCRIPTION
## Summary

When a single-line `TextBoxWidget` contains text that overflows the viewport and the cursor is at the end, pressing Backspace caused the cursor to visually drift left rather than staying pinned at the right edge. After several deletions the cursor ends up in the middle of the visible area, making it impossible to tell whether content is still hidden to the left.

**Root cause:** `_horizontalOffset` is only adjusted in `RenderSingleLine` when the cursor moves *past* a viewport boundary. When deletion moves the cursor one cell inward from the right edge, neither boundary condition fires, so the offset stays stale and the cursor appears one cell to the left.

## Fix

Added a third condition in `RenderSingleLine`: when the cursor is at the end of the line and `_horizontalOffset` is larger than needed to keep the cursor at the right edge, clamp it down.

```csharp
// When the cursor is at the end of the text and content is still scrolled off to the
// left, keep the cursor pinned to the right edge rather than letting it drift left as
// characters are deleted.
if (_cursorColumn == line.Count && _horizontalOffset > cursorCellPos - width + 1)
{
    _horizontalOffset = Math.Max(0, cursorCellPos - width + 1);
}
```

## Test

Added `Should_Keep_Cursor_Pinned_At_Right_Edge_When_Deleting_From_Overflowed_Text` to `TextBoxWidgetTests.TheRenderMethod`. It renders overflowed text once to establish the scroll offset, deletes one character, renders again, and asserts the cursor is still at the right edge.

All 334 existing tests continue to pass.